### PR TITLE
Modernize privacy policy page and clarify data usage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,57 +1,20 @@
 import 'package:flutter/material.dart';
+import 'src/presentation/pages/privacy_policy_page.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const App());
 }
 
-class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+class App extends StatelessWidget {
+  const App({super.key});
 
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: Padding(
-        padding: EdgeInsets.all(10),
-        child: Scaffold(
-          body: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Bem-vindo à Política de Privacidade da Maktub Company',
-                style: TextStyle(
-                  color: Colors.black,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 20,
-                ),
-              ),
-              SizedBox(height: 10),
-              Text(
-                'Usuários que utilizam nosso serviço são muito importantes para nós. Dessa forma, quando você começar a utilizar nossos serviços, gostaríamos que ficasse sabendo como estamos usando suas informações e o modo como estamos protegendo a sua privacidade. Nossa Política de Privacidade explica que tipo de informações coletamos. Sua privacidade é importante para nós, portanto, por favor reserve um tempo para conhecer nossas práticas. E, se você tiver alguma dúvida, entre em contato conosco.',
-              ),
-              SizedBox(height: 10),
-              Text(
-                'Informações que coletamos',
-                style: TextStyle(
-                  color: Colors.black,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 20,
-                ),
-              ),
-              SizedBox(height: 10),
-              Text(
-                'A Maktub Company, não coleta, armazena ou divulga nenhum tipo de informação que o seu usuário, eventualmente, venha a fornecer durante o uso de nossos aplicativos. Isso quer dizer que o usuário não precisa em nenhum momento informar qualquer tipo de dados de uso pessoal.',
-              ),
-            ],
-          ),
-        ),
-      ),
+      theme: ThemeData(useMaterial3: true),
+      home: const PrivacyPolicyPage(),
     );
   }
 }
+

--- a/lib/src/presentation/pages/privacy_policy_page.dart
+++ b/lib/src/presentation/pages/privacy_policy_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class PrivacyPolicyPage extends StatelessWidget {
+  const PrivacyPolicyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Política de Privacidade'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            _SectionTitle(
+              'Bem-vindo à Política de Privacidade da Maktub Company',
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Usuários que utilizam nosso serviço são muito importantes para nós. '
+              'Dessa forma, quando você começar a utilizar nossos serviços, '
+              'gostaríamos que ficasse sabendo como estamos usando suas informações '
+              'e o modo como protegemos a sua privacidade. Nossa Política de Privacidade '
+              'explica que tipo de informações coletamos. Sua privacidade é importante '
+              'para nós, portanto, por favor reserve um tempo para conhecer nossas '
+              'práticas. E, se você tiver alguma dúvida, entre em contato conosco.',
+            ),
+            SizedBox(height: 16),
+            _SectionTitle('Informações que coletamos'),
+            SizedBox(height: 8),
+            Text(
+              'A Maktub Company coleta alguns dados básicos, como informações de uso '
+              'e preferências, para melhorar nossos serviços. No entanto, esses dados '
+              'nunca são compartilhados com nenhuma entidade de terceiros.',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String text;
+
+  const _SectionTitle(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      text,
+      style: theme.textTheme.titleMedium?.copyWith(
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+}
+

--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,7 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Saiba como a Maktub Company coleta e protege seus dados sem compartilhar com terceiros.">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -29,7 +29,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>site_privacidade</title>
+  <title>Maktub Company - Política de Privacidade</title>
   <link rel="manifest" href="manifest.json">
 
   <script>


### PR DESCRIPTION
## Summary
- adopt Material 3 styling and extract a dedicated privacy policy page for cleaner architecture
- update privacy statement to note basic data collection without third-party sharing
- refresh web metadata with new title and description

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7220416548322a76c9a5b1b02f4da